### PR TITLE
ENH: now portable FS commits

### DIFF
--- a/portable_fs/sqlite/fs.py
+++ b/portable_fs/sqlite/fs.py
@@ -69,8 +69,15 @@ def cursor(connection):
     ...     c.execute(query)
     """
     c = connection.cursor()
-    yield c
-    c.close()
+    try:
+        yield c
+    except:
+        connection.rollback()
+        raise
+    else:
+        connection.commit()
+    finally:
+        c.close()
 
 
 class FileStoreDatabase(object):


### PR DESCRIPTION
Use MDS cursor context in FS as the FS one did not commit changes on closing.